### PR TITLE
Update closure.md: no need to change the function signature

### DIFF
--- a/solutions/functional-programing/closure.md
+++ b/solutions/functional-programing/closure.md
@@ -58,9 +58,7 @@ fn main() {
      // consume();
 }
 
-fn take<T>(_v: T) {
-
-}
+fn take<T>(_v: T) {}
 ```
 
 ```rust
@@ -80,9 +78,7 @@ fn main() {
      consume();
 }
 
-fn take<T>(_v: &T) {
-
-}
+fn take<T>(_v: T) {}
 ```
 
 4. 


### PR DESCRIPTION
Also there's a third solution: `take(*movable);` which makes the thing `Copy` and it flies flawlessly. It's kinda intense to see how the polar (`ref` and `deref`) solutions both works but for such the different reasons.

Maybe the boxed value should be changed to a non-copy type (then `Box` would be not even needed I guess?) to avoid this third solution?