### PR TITLE
Fix mutable borrow error in borrowing.md example

### DIFF
--- a/solutions/ownership/borrowing.md
+++ b/solutions/ownership/borrowing.md
@@ -149,6 +149,6 @@ fn main() {
 
     // add one line below to make a compiler error: cannot borrow `s` as mutable more than once at a time
     // you can't use r1 and r2 at the same time
-    println!("{}, {}", r1, r2);
+    println!("{}", r1);
 }
 ```

--- a/solutions/ownership/borrowing.md
+++ b/solutions/ownership/borrowing.md
@@ -147,7 +147,7 @@ fn main() {
     let r1 = &mut s;
     let r2 = &mut s;
 
-    // add one line below to make a compiler error: cannot borrow `s` as mutable more than once at a time
+    // Add one line below to make a compiler error: cannot borrow `s` as mutable more than once at a time
     // you can't use r1 and r2 at the same time
     println!("{}", r1);
 }


### PR DESCRIPTION
Updated println! macro to only use r1 to avoid mutable borrow error.