### PR TITLE
"Fix mdBook 0.5 playpen config (remove deprecated editor field)"

### DIFF
--- a/en/book.toml
+++ b/en/book.toml
@@ -5,8 +5,10 @@ authors = ["sunface, https://im.dev"]
 language = "en"
 
 [output.html.playpen]
+# mdBook 0.5+ removed `editor`; use explicit flags instead
 editable = true
-editor = "ace"
+copyable = true
+runnable = true
 
 [output.html.fold]
 enable = true


### PR DESCRIPTION
Removed the 'editor' field and added 'copyable' and 'runnable' fields in the output configuration.
Faced this error on mdbook version 0.5.2 (latest till date):
ERROR Failed to deserialize `output.html`
Caused by: unknown field `editor`, expected one of `editable`, `copyable`, `copy-js`, `line-numbers`, `runnable`
in `playpen`
<img width="1279" height="267" alt="Screenshot 2025-12-24 at 1 13 19 PM" src="https://github.com/user-attachments/assets/97261497-f083-4cbc-980d-75a24fa45630" />
