### PR TITLE
docs: duplicate example

### DIFF
--- a/solutions/ownership/ownership.md
+++ b/solutions/ownership/ownership.md
@@ -172,7 +172,7 @@ fn main() {
     let t = (String::from("hello"), String::from("world"));
 
     // fill the blanks
-    let (ref s1, ref s2) = t;
+    let (s1, s2) = t.clone();
 
     println!("{:?}, {:?}, {:?}", s1, s2, t); // -> "hello", "world", ("hello", "world")
 }


### PR DESCRIPTION
There was a duplicate example:
https://github.com/sunface/rust-by-practice/blob/master/solutions/ownership/ownership.md

Reverting the first solution to the one that was before there