### PR TITLE
fix: remove broken into_iter().collect() example in vector exercise

### DIFF
--- a/en/src/collections/vector.md
+++ b/en/src/collections/vector.md
@@ -80,10 +80,6 @@ fn main() {
     let v3 = Vec::__(s);
     assert_eq!(v2, v3);
 
-    // Iterators can be collected into vectors
-    let v4: Vec<i32> = [0; 10].into_iter().collect();
-    assert_eq!(v4, vec![0; 10]);
-
     println!("Success!");
  }
 ```

--- a/zh-CN/src/collections/vector.md
+++ b/zh-CN/src/collections/vector.md
@@ -81,11 +81,6 @@ fn main() {
     let s = "hello";
     let v3 = Vec::__(s);
     assert_eq!(v2, v3);
-
-    // 迭代器 Iterators 可以通过 collect 变成 Vec
-    let v4: Vec<i32> = [0; 10].into_iter().collect();
-    assert_eq!(v4, vec![0; 10]);
-
     println!("Success!")
  }
 ```


### PR DESCRIPTION
## Problem

In the vector exercise (question 3), the following code is included:

```rust
let v4: Vec<i32> = [0; 10].into_iter().collect();
assert_eq!(v4, vec![0; 10]);
```

This fails to compile because `[0; 10].into_iter()` yields `&i32` (not `i32`) on pre-2021 Rust editions, so `collect::<Vec<i32>>()` fails with:

```
error[E0277]: a value of type `Vec<i32>` cannot be built from an iterator over elements of type `&{integer}`
```

The solution file (`solutions/collections/Vector.md`) already removed this example, but the exercise pages (both `zh-CN` and `en`) still included it.

## Fix

Removed the `v4` related lines from both `zh-CN/src/collections/vector.md` and `en/src/collections/vector.md` to match the existing solution.